### PR TITLE
fix: refer to calltree

### DIFF
--- a/lua/litee/filetree/buffer.lua
+++ b/lua/litee/filetree/buffer.lua
@@ -1,4 +1,4 @@
-local config = require('litee.calltree.config').config
+local config = require('litee.filetree.config').config
 local panel_config = require('litee.lib.config').config["panel"]
 local lib_util_buf = require('litee.lib.util.buffer')
 

--- a/lua/litee/filetree/marshal.lua
+++ b/lua/litee/filetree/marshal.lua
@@ -14,7 +14,7 @@ local function resolve_file_name(uri)
 end
 
 -- marshal_func is a function which returns the necessary
--- values for marshalling a calltree node into a buffer
+-- values for marshalling a filetree node into a buffer
 -- line.
 function M.marshal_func(node)
     local icon_set = nil


### PR DESCRIPTION
Use `config` of `litee.calltree.config` in `buffer.lua`