### PR TITLE
fix: re-introduce help buffers

### DIFF
--- a/lua/litee/filetree/buffer.lua
+++ b/lua/litee/filetree/buffer.lua
@@ -1,17 +1,17 @@
-local config = require('litee.calltree.config').config
+local config = require('litee.filetree.config').config
 local panel_config = require('litee.lib.config').config["panel"]
 local lib_util_buf = require('litee.lib.util.buffer')
 
 local M = {}
 
 -- _setup_buffer performs an idempotent creation of
--- a calltree buffer.
+-- a filetree buffer.
 function M._setup_buffer(name, buf, tab)
     -- see if we can reuse a buffer that currently exists.
     if buf == nil or not vim.api.nvim_buf_is_valid(buf) then
         buf = vim.api.nvim_create_buf(false, false)
         if buf == 0 then
-            vim.api.nvim_err_writeln("calltree.buffer: buffer create failed")
+            vim.api.nvim_err_writeln("filetree.buffer: buffer create failed")
             return
         end
     else
@@ -21,7 +21,7 @@ function M._setup_buffer(name, buf, tab)
     -- set buf options
     vim.api.nvim_buf_set_name(buf, name .. ":" .. tab)
     vim.api.nvim_buf_set_option(buf, 'bufhidden', 'hide')
-    vim.api.nvim_buf_set_option(buf, 'filetype', 'calltree')
+    vim.api.nvim_buf_set_option(buf, 'filetype', 'filetree')
     vim.api.nvim_buf_set_option(buf, 'buftype', 'nofile')
     vim.api.nvim_buf_set_option(buf, 'modifiable', false)
     vim.api.nvim_buf_set_option(buf, 'swapfile', false)
@@ -47,6 +47,7 @@ function M._setup_buffer(name, buf, tab)
     vim.api.nvim_buf_set_keymap(buf, "n", "p", ":LTCopyFiletree<CR>", opts)
     vim.api.nvim_buf_set_keymap(buf, "n", "s", ":LTSelectFiletree<CR>", opts)
     vim.api.nvim_buf_set_keymap(buf, "n", "S", ":LTDeSelectFiletree<CR>", opts)
+    vim.api.nvim_buf_set_keymap(buf, "n", "?", ":lua require('litee.filetree').help(true)<CR>", opts)
 	if config.map_resize_keys then
            lib_util_buf.map_resize_keys(panel_config.orientation, buf, opts)
     end

--- a/lua/litee/filetree/help_buffer.lua
+++ b/lua/litee/filetree/help_buffer.lua
@@ -1,0 +1,68 @@
+local M = {}
+-- _setup_help_buffer performs an idempotent creation
+-- of the filetree help buffer
+--
+-- help_buf_handle : previous filetree help buffer handle
+-- or nil
+--
+-- returns:
+--   "buf_handle"  -- handle to a valid filetree help buffer
+function M._setup_help_buffer(help_buf_handle)
+    if
+        help_buf_handle == nil
+        or not vim.api.nvim_buf_is_valid(help_buf_handle)
+    then
+        local buf = vim.api.nvim_create_buf(false, false)
+        if buf == 0 then
+            vim.api.nvim_err_writeln("ui.help failed: buffer create failed")
+            return
+        end
+        help_buf_handle = buf
+        local lines = {
+            "FILETREE HELP:",
+            "press '?' to close",
+            "",
+            "KEYMAP:",
+            "Global---------------------------------------------------------------------------------------------",
+            "zo                 - expand a symbol",
+            "zc                 - collapse a symbol",
+            "zM                 - collapse all symbols",
+            "return             - jump to symbol",
+            "s                  - jump to symbol in a new split",
+            "v                  - jump to symbol in a new vsplit",
+            "t                  - jump to symbol in a new tab",
+            "d                  - show symbol details",
+            "H                  - hide this element from the panel, will appear again on toggle",
+            "x                  - remove this element from the panel, will not appear until another LSP request",
+            "Up,Down,Right,Left - resize the panel",
+            "i                  - show hover info for symbol",
+            "File Explorer.......................................................................................",
+            "n                  - create a new file",
+            "D                  - delete a new file or directory",
+            "d                  - create a directory",
+            "r                  - rename a file or directory",
+            "m                  - move a file or directory",
+            "p                  - copy a file or directory",
+            "s                  - select a file to perform an above action on",
+            "S                  - deselect a selected file"
+        }
+        vim.api.nvim_buf_set_lines(help_buf_handle, 0, #lines, false, lines)
+    end
+    -- set buf options
+    vim.api.nvim_buf_set_name(help_buf_handle, "Filetree Help")
+    vim.api.nvim_buf_set_option(help_buf_handle, 'bufhidden', 'hide')
+    vim.api.nvim_buf_set_option(help_buf_handle, 'filetype', 'filetree')
+    vim.api.nvim_buf_set_option(help_buf_handle, 'buftype', 'nofile')
+    vim.api.nvim_buf_set_option(help_buf_handle, 'modifiable', false)
+    vim.api.nvim_buf_set_option(help_buf_handle, 'swapfile', false)
+
+    -- set buffer local keymaps
+    local opts = {silent=true}
+    vim.api.nvim_buf_set_keymap(help_buf_handle, "n", "?", ":lua require('litee.filetree').help(false)<CR>", opts)
+
+    return help_buf_handle
+end
+
+M.help_buffer = M._setup_help_buffer(nil)
+
+return M

--- a/lua/litee/filetree/init.lua
+++ b/lua/litee/filetree/init.lua
@@ -7,7 +7,9 @@ local lib_notify        = require('litee.lib.notify')
 local lib_jumps         = require('litee.lib.jumps')
 local lib_navi          = require('litee.lib.navi')
 local lib_util_win      = require('litee.lib.util.window')
+
 local filetree_buf      = require('litee.filetree.buffer')
+local filetree_help_buf = require('litee.filetree.help_buffer')
 local marshal_func      = require('litee.filetree.marshal').marshal_func
 local config            = require('litee.filetree.config').config
 
@@ -651,6 +653,23 @@ function M.on_tab_closed(tab)
         return
     end
     lib_tree.remove_tree(state["filetree"].tree)
+end
+
+function M.help(display)
+    local ctx = ui_req_ctx()
+    if
+        ctx.state == nil or
+        ctx.cursor == nil or
+        ctx.state["filetree"].tree == nil
+    then
+        lib_notify.notify_popup_with_timeout("Must open a filetree first with LTOpenFiletree command", 1750, "error")
+        return
+    end
+    if display then
+        vim.api.nvim_win_set_buf(ctx.state["filetree"].win, filetree_help_buf.help_buffer)
+    else
+        vim.api.nvim_win_set_buf(ctx.state["filetree"].win, ctx.state["filetree"].buf)
+    end
 end
 
 function M.dump_tree()

--- a/lua/litee/filetree/marshal.lua
+++ b/lua/litee/filetree/marshal.lua
@@ -14,7 +14,7 @@ local function resolve_file_name(uri)
 end
 
 -- marshal_func is a function which returns the necessary
--- values for marshalling a calltree node into a buffer
+-- values for marshalling a filetree node into a buffer
 -- line.
 function M.marshal_func(node)
     local icon_set = nil


### PR DESCRIPTION
help buffers were lost in the refactor to separate plugins. this commit
adds them back

Signed-off-by: ldelossa <louis.delos@gmail.com>