### PR TITLE
feat,popout: this commit wires in litee.nvim popout feature

### DIFF
--- a/doc/litee-filetree.txt
+++ b/doc/litee-filetree.txt
@@ -84,6 +84,8 @@ To toggle the panel open and close use the following command
     -- panel component. Only valid if a Filetree is open and "LTCloseFiletree" has
     -- not been called on the current tab.
     vim.cmd("command! LTOpenToFiletree      lua require('litee.filetree').open_to()")
+    -- Uses litee.nvim's Popout feature to popout the filetree to a floating window.
+    vim.cmd("command! LTPopOutFiletree      lua require('litee.filetree').popout_to()")
     -- When called on a specific tabpage any filetree UI will be closed and cleared
     -- from the panel. Toggling the panel will not open the most recent Filetree.
     vim.cmd("command! LTCloseFiletree       lua require('litee.filetree').close_filetree()")
@@ -193,7 +195,10 @@ The config table is described below:
         -- If true each node in the filetree will be rendereed with
         -- its relative path from root. 
         -- Can be useful when the Filetree window is longer then it is tall.
-        relative_filetree_entries = false
+        relative_filetree_entries = false,
+        -- Determines if initial creation of a filetree opens in the
+        -- Panel or in a Popout window. Options are "panel" or "popout"
+        on_open = "popout"
     }
 
 Any overrides to this table can be supplied in the setup function:

--- a/lua/litee/filetree/buffer.lua
+++ b/lua/litee/filetree/buffer.lua
@@ -47,6 +47,7 @@ function M._setup_buffer(name, buf, tab)
     vim.api.nvim_buf_set_keymap(buf, "n", "p", ":LTCopyFiletree<CR>", opts)
     vim.api.nvim_buf_set_keymap(buf, "n", "s", ":LTSelectFiletree<CR>", opts)
     vim.api.nvim_buf_set_keymap(buf, "n", "S", ":LTDeSelectFiletree<CR>", opts)
+    vim.api.nvim_buf_set_keymap(buf, "n", "<Esc>", ":LTClosePanelPopOut<CR>", opts)
     vim.api.nvim_buf_set_keymap(buf, "n", "?", ":lua require('litee.filetree').help(true)<CR>", opts)
 	if config.map_resize_keys then
            lib_util_buf.map_resize_keys(panel_config.orientation, buf, opts)

--- a/lua/litee/filetree/commands.lua
+++ b/lua/litee/filetree/commands.lua
@@ -3,6 +3,7 @@ local M = {}
 function M.setup()
     vim.cmd("command! LTOpenFiletree          lua require('litee.filetree.handlers').filetree_handler()")
     vim.cmd("command! LTOpenToFiletree        lua require('litee.filetree').open_to()")
+    vim.cmd("command! LTPopOutFiletree        lua require('litee.filetree').popout_to()")
     vim.cmd("command! LTCloseFiletree         lua require('litee.filetree').close_filetree()")
     vim.cmd("command! LTHideFiletree          lua require('litee.filetree').hide_filetree()")
     vim.cmd("command! LTNextFiletree          lua require('litee.filetree').navigation('n')")

--- a/lua/litee/filetree/config.lua
+++ b/lua/litee/filetree/config.lua
@@ -6,7 +6,8 @@ M.config = {
     select_hi   = "LTSelectFiletree",
     map_resize_keys = true,
     use_web_devicons = true,
-    relative_filetree_entries = false
+    relative_filetree_entries = false,
+    on_open = "popup",
 }
 
 return M

--- a/lua/litee/filetree/handlers.lua
+++ b/lua/litee/filetree/handlers.lua
@@ -2,8 +2,11 @@ local lib_state         = require('litee.lib.state')
 local lib_panel         = require('litee.lib.panel')
 local lib_tree          = require('litee.lib.tree')
 local lib_tree_node     = require('litee.lib.tree.node')
+
+local config            = require('litee.filetree.config').config
 local filetree          = require('litee.filetree')
 local filetree_au       = require('litee.filetree.autocmds')
+local filetree_marshal  = require('litee.filetree.marshal')
 
 
 local M = {}
@@ -13,23 +16,24 @@ local M = {}
 function M.filetree_handler()
     local cur_win = vim.api.nvim_get_current_win()
     local cur_tabpage = vim.api.nvim_win_get_tabpage(cur_win)
+    local state_was_nil = false
 
     local state = lib_state.get_component_state(cur_tabpage, "filetree")
     if state == nil then
+        state_was_nil = true
         state = {}
+        -- create new tree, throwing old one out if exists
+        if state.filetree_handle ~= nil then
+            lib_tree.remove_tree(state.tree)
+        end
+        state.tree = lib_tree.new_tree("filetree")
+        -- store the window invoking the filetree, jumps will
+        -- occur here.
+        state.invoking_win = vim.api.nvim_get_current_win()
+        -- store the tab which invoked the filetree.
+        state.tab = cur_tabpage
     end
 
-    if state.filetree_handle ~= nil then
-        lib_tree.remove_tree(state.tree)
-    end
-    state.tree = lib_tree.new_tree("filetree")
-
-    -- store the window invoking the filetree, jumps will
-    -- occur here.
-    state.invoking_win = vim.api.nvim_get_current_win()
-
-    -- store the tab which invoked the filetree.
-    state.tab = cur_tabpage
 
     -- get the current working directory
     local cwd = vim.fn.getcwd()
@@ -53,7 +57,29 @@ function M.filetree_handler()
 
     local global_state = lib_state.put_component_state(cur_tabpage, "filetree", state)
 
-    lib_panel.toggle_panel(global_state, true, false)
+    -- state was not nil, can we reuse the existing win
+    -- and buffer?
+    if
+        not state_was_nil
+        and state.win ~= nil
+        and vim.api.nvim_win_is_valid(state.win)
+        and state.buf ~= nil
+        and vim.api.nvim_buf_is_valid(state.buf)
+    then
+        lib_tree.write_tree(
+            state.buf,
+            state.tree,
+            filetree_marshal.marshal_func
+        )
+    else
+        -- we have no state, so open up the panel or popout to create
+        -- a window and buffer.
+        if config.on_open == "popout" then
+            lib_panel.popout_to("filetree", global_state)
+        else
+            lib_panel.toggle_panel(global_state, true, false)
+        end
+    end
 
     -- run file_tracking to initially update filetree view.
     filetree_au.file_tracking()


### PR DESCRIPTION
this commit wires in the new litee.nvim popout feature.

the filetree can now be popped out from the panel to a floating window
with the command "LTPopOutFiletree"

additionally a config option "on_open" is added which takes the
arguments "popout" or "panel". if set to "panel" the first request for a
filetree is opened in the panel, same goes for "popout".