### PR TITLE
feat,cd: implementing changing directories in tree and rework renaming

### DIFF
--- a/lua/litee/filetree/autocmds.lua
+++ b/lua/litee/filetree/autocmds.lua
@@ -1,8 +1,9 @@
 local lib_tree          = require('litee.lib.tree')
 local lib_state         = require('litee.lib.state')
 local marshal_func      = require('litee.filetree.marshal').marshal_func
-local filetree          = require('litee.filetree')
 local lib_util_win      = require('litee.lib.util.window')
+
+local builder           = require('litee.filetree.builder')
 
 local M = {}
 
@@ -80,7 +81,7 @@ M.file_tracking = function()
     end
     local dpt = t.depth_table
     local target_uri = vim.fn.expand('%:p')
-    filetree.build_filetree_recursive(t.root, ctx.state["filetree"], dpt, target_uri)
+    builder.build_filetree_recursive(t.root, ctx.state["filetree"], dpt, target_uri)
     lib_tree.write_tree(
         ctx.state["filetree"].buf,
         ctx.state["filetree"].tree,

--- a/lua/litee/filetree/buffer.lua
+++ b/lua/litee/filetree/buffer.lua
@@ -47,6 +47,10 @@ function M._setup_buffer(name, buf, tab)
     vim.api.nvim_buf_set_keymap(buf, "n", "p", ":LTCopyFiletree<CR>", opts)
     vim.api.nvim_buf_set_keymap(buf, "n", "s", ":LTSelectFiletree<CR>", opts)
     vim.api.nvim_buf_set_keymap(buf, "n", "S", ":LTDeSelectFiletree<CR>", opts)
+    vim.api.nvim_buf_set_keymap(buf, "n", "cd", ":LTChangeDirFiletree<CR>", opts)
+    vim.api.nvim_buf_set_keymap(buf, "n", "cu", ":LTUpDirFiletree<CR>", opts)
+    vim.api.nvim_buf_set_keymap(buf, "n", "S", ":LTDeSelectFiletree<CR>", opts)
+
     vim.api.nvim_buf_set_keymap(buf, "n", "<Esc>", ":LTClosePanelPopOut<CR>", opts)
     vim.api.nvim_buf_set_keymap(buf, "n", "?", ":lua require('litee.filetree').help(true)<CR>", opts)
 	if config.map_resize_keys then

--- a/lua/litee/filetree/builder.lua
+++ b/lua/litee/filetree/builder.lua
@@ -1,0 +1,66 @@
+local lib_tree          = require('litee.lib.tree')
+local lib_tree_node     = require('litee.lib.tree.node')
+
+local M = {}
+
+-- expand expands a filetree_item in the tree, refreshing the sub directory
+-- incase new content exists.
+function M.expand(root, component_state)
+    root.expanded = true
+    local children = {}
+    local files = vim.fn.readdir(root.filetree_item.uri)
+    for _, child in ipairs(files) do
+        local uri = root.filetree_item.uri .. "/" .. child
+        local is_dir = vim.fn.isdirectory(uri)
+        local child_node = lib_tree_node.new_node(child, uri, 0)
+        child_node.filetree_item = {
+            uri = uri,
+            is_dir = (function() if is_dir == 0 then return false else return true end end)()
+        }
+        local range = {}
+        range["start"] = { line = 0, character = 0}
+        range["end"] = { line = 0, character = 0}
+        child_node.location = {
+            uri = "file://" .. child_node.filetree_item.uri,
+            range = range
+        }
+        table.insert(children, child_node)
+    end
+    lib_tree.add_node(component_state.tree, root, children)
+end
+
+function M.build_filetree_recursive(root, component_state, old_dpt, expand_dir)
+    root.children = {}
+    local old_node = nil
+    if old_dpt ~= nil then
+        old_node = lib_tree.search_dpt(old_dpt, root.depth, root.key)
+    end
+    if old_node == nil then
+        -- just makes it easier to shove into the if clause below.
+        old_node = {}
+    end
+    local should_expand = false
+    -- if we are provided a directory to expand check
+    -- if the current root in the path to it and if so
+    -- mark it for expansion.
+    if expand_dir ~= nil and expand_dir ~= "" then
+        local idx = vim.fn.stridx(expand_dir, root.filetree_item.uri)
+        if idx ~= -1 then
+            should_expand = true
+        end
+    end
+    if
+        root.depth == 0 or
+        old_node.expanded or
+        should_expand
+    then
+        M.expand(root, component_state)
+    end
+    for _, child in ipairs(root.children) do
+        if child.filetree_item.is_dir then
+            M.build_filetree_recursive(child, component_state, old_dpt, expand_dir)
+        end
+    end
+end
+
+return M

--- a/lua/litee/filetree/commands.lua
+++ b/lua/litee/filetree/commands.lua
@@ -25,6 +25,9 @@ function M.setup()
     vim.cmd("command! LTMoveFiletree          lua require('litee.filetree').filetree_ops('mv')")
     vim.cmd("command! LTMkdirFiletree         lua require('litee.filetree').filetree_ops('mkdir')")
     vim.cmd("command! LTRenameFiletree        lua require('litee.filetree').filetree_ops('rename')")
+    vim.cmd("command! LTChangeDirFiletree     lua require('litee.filetree').cd()")
+    vim.cmd("command! LTUpDirFiletree         lua require('litee.filetree').cd_up()")
+
 end
 
 return M

--- a/lua/litee/filetree/handlers.lua
+++ b/lua/litee/filetree/handlers.lua
@@ -4,16 +4,16 @@ local lib_tree          = require('litee.lib.tree')
 local lib_tree_node     = require('litee.lib.tree.node')
 
 local config            = require('litee.filetree.config').config
-local filetree          = require('litee.filetree')
 local filetree_au       = require('litee.filetree.autocmds')
 local filetree_marshal  = require('litee.filetree.marshal')
+local builder            = require('litee.filetree.builder')
 
 
 local M = {}
 
 -- filetree_handler handles the initial request for creating a filetree
 -- for a particular tab.
-function M.filetree_handler()
+function M.filetree_handler(root_dir)
     local cur_win = vim.api.nvim_get_current_win()
     local cur_tabpage = vim.api.nvim_win_get_tabpage(cur_win)
     local state_was_nil = false
@@ -35,8 +35,10 @@ function M.filetree_handler()
     end
 
 
-    -- get the current working directory
     local cwd = vim.fn.getcwd()
+    if root_dir ~= nil or root_dir == "" then
+        cwd = root_dir
+    end
 
     -- create the root of our filetree
     local root = lib_tree_node.new_node(
@@ -53,7 +55,7 @@ function M.filetree_handler()
         range = range
     }
 
-    filetree.build_filetree_recursive(root, state, nil, "")
+    builder.build_filetree_recursive(root, state, nil, "")
 
     local global_state = lib_state.put_component_state(cur_tabpage, "filetree", state)
 


### PR DESCRIPTION
this commit adds the ability to change the root directory of a spawned
tree to an arbitrary one.

additionally, it reworks how advanced renaming works.

another command is added to move to the parent of the current root.

Signed-off-by: ldelossa <louis.delos@gmail.com>