### PR TITLE
useability: make "jumps" on dirs expand

### DIFF
--- a/doc/litee-filetree.txt
+++ b/doc/litee-filetree.txt
@@ -215,6 +215,10 @@ The config table is described below:
         -- Highlight group used to indicate the currently opened
         -- file.
         current_file_hl = "LTCurrentFileFiletree",
+        -- When true issuing a "jump" on a directory expands
+        -- or closes the directory instead of opening it
+        -- like a buffer.
+        expand_dir_on_jump = true,
         -- If set to true, disables all buffer keymaps.
         disable_keymaps = false,
         -- The default keymaps. Users can provide overrides

--- a/lua/litee/filetree/config.lua
+++ b/lua/litee/filetree/config.lua
@@ -9,6 +9,7 @@ M.config = {
     relative_filetree_entries = false,
     on_open = "popup",
     current_file_hl = "LTCurrentFileFiletree",
+    expand_dir_on_jump = true,
     disable_keymaps = false,
     keymaps = {
         expand = "zo",


### PR DESCRIPTION
this commit adds a new option (defaults to on) which expands a directory
when "LTJumpFiletree" and friends are called on a directory node.

jumps on files still open in a buffer like you'd expect.

Signed-off-by: ldelossa <louis.delos@gmail.com>