### PR TITLE
fix,feat: current file highlights, new file open

### DIFF
--- a/lua/litee/filetree/autocmds.lua
+++ b/lua/litee/filetree/autocmds.lua
@@ -60,7 +60,7 @@ local function ui_req_ctx()
     }
 end
 
-M.current_file_hl_group = nil
+M.current_file_hl_ns = nil
 
 -- file_tracking is used to keep the filetree up to date
 -- with the focused source file buffer.
@@ -77,10 +77,10 @@ M.file_tracking = function()
     then
         return
     end
-    if M.current_file_hl_group ~= nil then
+    if M.current_file_hl_ns ~= nil then
         vim.api.nvim_buf_clear_namespace(
             ctx.state["filetree"].buf,
-            M.current_file_hl_group,
+            M.current_file_hl_ns,
             0,
             -1
         )
@@ -102,9 +102,7 @@ M.file_tracking = function()
     for buf_line, node in pairs(t.buf_line_map) do
         if node.key == target_uri then
             vim.api.nvim_win_set_cursor(ctx.state["filetree"].win, {buf_line, 0})
-            -- set a hl that's same color as cursor line so you can always find current
-            -- file.
-            M.current_file_hl_group = vim.api.nvim_buf_add_highlight(
+            M.current_file_hl_ns = vim.api.nvim_buf_add_highlight(
                 ctx.state["filetree"].buf,
                 0,
                 config.current_file_hl,

--- a/lua/litee/filetree/config.lua
+++ b/lua/litee/filetree/config.lua
@@ -10,6 +10,7 @@ M.config = {
     on_open = "popup",
     current_file_hl = "LTCurrentFileFiletree",
     expand_dir_on_jump = true,
+    open_new_file = true,
     disable_keymaps = false,
     keymaps = {
         expand = "zo",

--- a/lua/litee/filetree/init.lua
+++ b/lua/litee/filetree/init.lua
@@ -17,6 +17,7 @@ local details_func      = require('litee.filetree.details').details_func
 local config            = require('litee.filetree.config').config
 local builder           = require('litee.filetree.builder')
 local handlers          = require('litee.filetree.handlers')
+local autocmd           = require('litee.filetree.autocmds')
 
 local M = {}
 
@@ -168,6 +169,13 @@ function M.collapse_filetree(extrn_ctx)
         ctx.state["filetree"].tree,
         marshal_func
     )
+
+    -- call filetracking to set LTCurrentFileFiletree highlight
+    local cur_win = vim.api.nvim_get_current_win()
+    vim.api.nvim_set_current_win(ctx.state["filetree"].invoking_win)
+    autocmd.file_tracking()
+    vim.api.nvim_set_current_win(cur_win)
+
     vim.api.nvim_win_set_cursor(ctx.state["filetree"].win, ctx.cursor)
 end
 
@@ -214,6 +222,13 @@ M.expand_filetree = function(extrn_ctx)
         ctx.state["filetree"].tree,
         marshal_func
     )
+
+    -- call filetracking to set LTCurrentFileFiletree highlight
+    local cur_win = vim.api.nvim_get_current_win()
+    vim.api.nvim_set_current_win(ctx.state["filetree"].invoking_win)
+    autocmd.file_tracking()
+    vim.api.nvim_set_current_win(cur_win)
+
     vim.api.nvim_win_set_cursor(ctx.state["filetree"].win, ctx.cursor)
 end
 
@@ -360,6 +375,13 @@ function M.touch(node, component_state, cb)
             if vim.fn.writefile({},touch_path) == -1 then
                 return
             end
+        end
+
+        -- open the new file so filetracking autocmd is ran
+        if config.open_new_file then
+            vim.api.nvim_set_current_win(component_state.invoking_win)
+            vim.cmd("edit " .. touch_path)
+            autocmd.file_tracking()
         end
 
         local t = lib_tree.get_tree(component_state.tree)


### PR DESCRIPTION
introduce a feature which opens a newly created file and also ensure
current file highlight stays when collapsing or expanding a node.

Signed-off-by: ldelossa <louis.delos@gmail.com>